### PR TITLE
Feat: compatibility with huge changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ All content is sourced with [Daily-snapshot](https://github.com/tgenaitay/daily-
 ## Execution
 
 - CRON: This node script runs daily via **Github actions**, shortly after midnight. See [Daily-changes.yml](https://github.com/tgenaitay/daily-change/blob/main/.github/workflows/daily-changes.yml) for details.
-- LLMs: This service relies on `Llama 3.1 70b` for diff and `Llama 3.1 8b` for subsequent classification. Both are currently through the free OpenAI-compatible endpoints on [Scaleway](https://www.scaleway.com/en/generative-apis/).
+- LLMs: This service relies on `Gemini-2.0-Flash` for diff and `Gemini-2.0-Flash-Lite` for subsequent classification. Both are sponsored by the generous free-tier from [Gemini Developer API](https://ai.google.dev/gemini-api/docs).
 - Supabase: Postgres database where sources, snapshots and changes are fetched / stored.
 - Literal: instrumentation service for our LLM calls.
 
@@ -16,7 +16,7 @@ All content is sourced with [Daily-snapshot](https://github.com/tgenaitay/daily-
 1. **Set `.env` variables:**
 
 ```
-SCALEWAY_API_KEY=XX
+GOOGLE_API_KEY=XX
 SUPABASE_URL=XX
 SUPABASE_ANON_KEY=XX
 LITERAL_API_KEY=XX

--- a/change-job.js
+++ b/change-job.js
@@ -3,6 +3,7 @@ const OpenAI = require('openai');
 const { LiteralClient } = require('@literalai/client');
 const { computeDiffs } = require('./services/diff-computation');
 const { classifyChanges } = require('./services/classification');
+const { createRateLimitedClient } = require('./services/rate-limiter');
 
 // Only load dotenv if running locally
 if (process.env.NODE_ENV !== 'production') {
@@ -20,20 +21,35 @@ async function main() {
   const supabaseKey = process.env.SUPABASE_ANON_KEY;
   const supabase = createClient(supabaseUrl, supabaseKey);
 
-  // Initialize OpenAI client for Scaleway
-  const scwApiKey = process.env.SCALEWAY_API_KEY;
+  // // Initialize OpenAI client for Scaleway
+  // const scwApiKey = process.env.SCALEWAY_API_KEY;
+  // const openai = new OpenAI({
+  //   apiKey: scwApiKey,
+  //   baseURL: 'https://api.scaleway.ai/32c4ba40-7c02-4c97-886f-48d7c8a87755/v1',
+  // });
+
+  // Initialize OpenAI client for Gemini
+  const geminiApiKey = process.env.GOOGLE_API_KEY;
   const openai = new OpenAI({
-    apiKey: scwApiKey,
-    baseURL: 'https://api.scaleway.ai/32c4ba40-7c02-4c97-886f-48d7c8a87755/v1',
+    apiKey: geminiApiKey,
+    baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai/',
   });
+
+  // Create rate-limited client
+  const rateLimitedOpenAI = createRateLimitedClient(openai);
+
+  const differ = 'gemini-2.0-flash'; // this model will analyze the difference between two large strings and output a summary in JSON format. Large context matters.
+  const classifier = 'gemini-2.0-flash-lite'; // this model will review the diff, tag it and explain its classification, all in JSON schema. Smaller models can do.
+
+  // setting both at flash-lite for its 30 RPM rate limit on free tier https://ai.google.dev/gemini-api/docs/rate-limits#free-tier
 
   literalClient.instrumentation.openai();
 
   console.log('Starting diff computation...');
-  await computeDiffs(supabase, openai);
+  await computeDiffs(supabase, rateLimitedOpenAI, differ);
 
   console.log('Starting classification...');
-  await classifyChanges(supabase, openai);
+  await classifyChanges(supabase, rateLimitedOpenAI, classifier);
 
   console.log('Daily changes job completed');
 }

--- a/services/classification.js
+++ b/services/classification.js
@@ -2,8 +2,9 @@
  * Classifies unclassified changes using an LLM.
  * @param {Object} supabase - Supabase client instance
  * @param {Object} openai - OpenAI client instance
+ * @param {string} model - Model name used for classifyng changes
  */
-async function classifyChanges(supabase, openai) {
+async function classifyChanges(supabase, openai, model) {
   // Fetch unclassified changes with their source URLs
   const { data: changes, error: changesError } = await supabase
     .from('changes')
@@ -63,7 +64,7 @@ async function classifyChanges(supabase, openai) {
 
     try {
       const response = await openai.chat.completions.create({
-        model: 'llama-3.1-8b-instruct',
+        model: model,
         messages: [
           { role: 'system', content: 'You are a helpful assistant that strictly follows instructions and provides structured JSON responses.' },
           { role: 'user', content: prompt },

--- a/services/rate-limiter.js
+++ b/services/rate-limiter.js
@@ -1,0 +1,68 @@
+/**
+ * Rate limiting service for API clients
+ */
+
+// Rate limiting configuration for different models
+const RATE_LIMITS = {
+  'gemini-2.0-flash': 15, // 15 RPM
+  'gemini-2.0-flash-lite': 30, // 30 RPM
+  // Add other models as needed
+};
+
+// Rate limiting state
+const rateLimitState = {
+  lastRequestTime: {},
+};
+
+/**
+ * Creates a rate-limited OpenAI client wrapper
+ * @param {Object} openai - Original OpenAI client
+ * @param {Object} rateLimits - Map of model names to their RPM limits (optional)
+ * @returns {Object} Rate-limited OpenAI client
+ */
+function createRateLimitedClient(openai, rateLimits = RATE_LIMITS) {
+  // Create a proxy to intercept API calls
+  const rateLimitedClient = {
+    ...openai,
+    chat: {
+      ...openai.chat,
+      completions: {
+        create: async (params) => {
+          const model = params.model;
+          const rpm = rateLimits[model] || 15; // Default to 15 RPM if model not found
+          
+          // Calculate minimum delay between requests
+          const minDelayMs = 60000 / rpm;
+          
+          // Initialize last request time for this model if not exists
+          if (!rateLimitState.lastRequestTime[model]) {
+            rateLimitState.lastRequestTime[model] = 0;
+          }
+          
+          // Apply rate limiting
+          const now = Date.now();
+          const timeElapsed = now - rateLimitState.lastRequestTime[model];
+          
+          if (timeElapsed < minDelayMs) {
+            const delayNeeded = minDelayMs - timeElapsed;
+            console.log(`Rate limiting for ${model}: waiting ${delayNeeded}ms before next request`);
+            await new Promise(resolve => setTimeout(resolve, delayNeeded));
+          }
+          
+          // Update last request time
+          rateLimitState.lastRequestTime[model] = Date.now();
+          
+          // Make the actual API call
+          return openai.chat.completions.create(params);
+        }
+      }
+    }
+  };
+  
+  return rateLimitedClient;
+}
+
+module.exports = {
+  createRateLimitedClient,
+  RATE_LIMITS
+};


### PR DESCRIPTION
- Moved to Gemini's free tier, 
- Added rate limiter to avoid hitting max, 
- Catching and cleaning falsy JSON output in case we hit a finish reason: length (e.g OpenAI API specs)

Learnings:
- Gemini-2.0-flash-lite repeats itself when the input is huge, won't stop despite being asked to behave in prompt. Same issue happened with Llama-3.1-8b. Must have a big model for the diff job.
- Length issue was meant to happen with max_tokens anyway, now caught every time